### PR TITLE
Explicitly clear cookies before attempting a new login

### DIFF
--- a/myusps/__init__.py
+++ b/myusps/__init__.py
@@ -143,6 +143,7 @@ def _get_login_metadata(session):
 def _login(session):
     """Login."""
     _LOGGER.debug("attempting login")
+    session.cookies.clear()
     token, uuid_token, payload_key = _get_login_metadata(session)
     resp = session.post(AUTHENTICATE_URL, {
         'username':  session.auth.username,


### PR DESCRIPTION
Explicitly clearing the session cookies prior to attempting a new login seems to have corrected the occasional issue where the presence of an existing pickle file causes login to fail on a new start of the library.

The only explanation I can think of is that the existing (no longer valid) session cookie interferes with the new login attempt generating a bad authentication result.