### PR TITLE
Include support for Firefox webdriver

### DIFF
--- a/myusps/__init__.py
+++ b/myusps/__init__.py
@@ -14,6 +14,7 @@ from selenium import webdriver
 from selenium.common.exceptions import TimeoutException, WebDriverException
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.firefox.options import Options
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,6 +37,8 @@ CHROME_WEBDRIVER_ARGS = [
     '--headless', '--user-agent={}'.format(USER_AGENT), '--disable-extensions',
     '--disable-gpu', '--no-sandbox'
 ]
+FIREFOXOPTIONS = Options()
+FIREFOXOPTIONS.add_argument("--headless")
 
 
 class USPSError(Exception):
@@ -142,6 +145,8 @@ def _get_driver(driver_type):
     """Get webdriver."""
     if driver_type == 'phantomjs':
         return webdriver.PhantomJS(service_log_path=os.path.devnull)
+    if driver_type == 'firefox':
+        return webdriver.Firefox(firefox_options=FIREFOXOPTIONS)
     elif driver_type == 'chrome':
         chrome_options = webdriver.ChromeOptions()
         for arg in CHROME_WEBDRIVER_ARGS:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='happyleaves',
     author_email='happyleaves.tfr@gmail.com',
     packages=find_packages(),
-    install_requires=['beautifulsoup4==4.6.0', 'python-dateutil==2.6.0', 'requests==2.12.4', 'requests-cache==0.4.13', 'selenium==2.53.6'],
+    install_requires=['beautifulsoup4==4.6.0', 'python-dateutil==2.6.0', 'requests==2.12.4', 'requests-cache==0.4.13', 'selenium==3.11.0)'],
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='happyleaves',
     author_email='happyleaves.tfr@gmail.com',
     packages=find_packages(),
-    install_requires=['beautifulsoup4==4.6.0', 'python-dateutil==2.6.0', 'requests==2.12.4', 'requests-cache==0.4.13', 'selenium==3.11.0)'],
+    install_requires=['beautifulsoup4==4.6.0', 'python-dateutil==2.6.0', 'requests==2.12.4', 'requests-cache==0.4.13', 'selenium==3.11.0'],
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
I've gone ahead and switched the default Selenium webdriver to Firefox, as there appears to be a recent change to the MyUSPS login form that is stopping Chromedriver or PhantomJS from being able to establish a session. The below code switches the default webdriver from PhantomJS to Firefox, implements other changes needed to support that WebDriver, and updates the default selenium version to 3.11 (the latest). This allows the library to work again in Windows and Linux.